### PR TITLE
Update textView properties with didSet

### DIFF
--- a/ALTextInputBar/ALTextInputBar.swift
+++ b/ALTextInputBar/ALTextInputBar.swift
@@ -24,16 +24,32 @@ public class ALTextInputBar: UIView, ALTextViewDelegate {
     public var textViewBorderPadding: UIEdgeInsets = UIEdgeInsetsMake(6, 8, 6, 8)
     
     // TextView corner radius
-    public var textViewCornerRadius: CGFloat = 4
+    public var textViewCornerRadius: CGFloat = 4 {
+        didSet {
+            textViewBorderView.layer.cornerRadius = textViewCornerRadius
+        }
+    }
     
     // TextView border width
-    public var textViewBorderWidth: CGFloat = 1
+    public var textViewBorderWidth: CGFloat = 1 {
+        didSet {
+            textViewBorderView.layer.borderWidth = textViewBorderWidth
+        }
+    }
     
     // TextView border color
-    public var textViewBorderColor = UIColor(white: 0.9, alpha: 1)
+    public var textViewBorderColor = UIColor(white: 0.9, alpha: 1) {
+        didSet {
+            textViewBorderView.layer.borderColor = textViewBorderColor.CGColor
+        }
+    }
     
     // TextView background color
-    public var textViewBackgroundColor = UIColor.whiteColor()
+    public var textViewBackgroundColor = UIColor.whiteColor() {
+        didSet {
+            textViewBorderView.backgroundColor = textViewBackgroundColor
+        }
+    }
     
     /// Used for the intrinsic content size for autolayout
     public var defaultHeight: CGFloat = 44


### PR DESCRIPTION
Several textView properties are not updating properly, because they are only read at initialization (and it's impossible to set them before the view is initialized).

This PR updates these properties to set themselves in `didSet`, so they will work as expected.
