### PR TITLE
Do caretRect: in main thread

### DIFF
--- a/ALTextInputBar/ALTextView.swift
+++ b/ALTextInputBar/ALTextView.swift
@@ -172,11 +172,15 @@ public class ALTextView: UITextView {
     Ensure that when the text view is resized that the caret displays correctly withing the visible space
     */
     private func ensureCaretDisplaysCorrectly() {
-        if let s = selectedTextRange {
-            let rect = caretRect(for: s.end)
-            UIView.performWithoutAnimation({ () -> Void in
+        guard let range = selectedTextRange else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            let rect = self.caretRect(for: range.end)
+            UIView.performWithoutAnimation {
                 self.scrollRectToVisible(rect, animated: false)
-            })
+            }
         }
     }
     


### PR DESCRIPTION
Hello! 

This Pull Request is to fix #31.
`caretRect(for: )` is need to exec on main thread. so, I moved this function call in `DispatchQueue.main.async`.
