### PR TITLE
Fixed incorrect calculation in roundHeight method.

### DIFF
--- a/ALTextInputBar/ALTextView.swift
+++ b/ALTextInputBar/ALTextView.swift
@@ -156,7 +156,7 @@ public class ALTextView: UITextView {
         
         if let font = font {
             let attributes = [NSFontAttributeName: font]
-            let boundingSize = CGSize(width: frame.size.width - textContainerInset.left - textContainerInset.bottom, height: .greatestFiniteMagnitude)
+            let boundingSize = CGSize(width: frame.size.width - textContainerInset.left - textContainerInset.right, height: .greatestFiniteMagnitude)
             let size = text.boundingRect(with: boundingSize, options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
             newHeight = ceil(size.height)
         }


### PR DESCRIPTION
The calculation below which is found in the `roundHeight()` method of `ALTextView` seems to be incorrect. It should be using `textContainerInset.right` property instead of `textContainerInset.bottom` to calculate width for the bounding size.

```swift
let boundingSize = CGSize(width: frame.size.width - textContainerInset.left - textContainerInset.bottom, height: .greatestFiniteMagnitude)
```