### PR TITLE
Swift 4 compatibility

### DIFF
--- a/ALTextInputBar/ALTextView.swift
+++ b/ALTextInputBar/ALTextView.swift
@@ -153,7 +153,7 @@ public class ALTextView: UITextView {
         var newHeight: CGFloat = 0
         
         if let font = font {
-            let attributes = [NSFontAttributeName: font]
+            let attributes = [NSFontAttributeKey: font]
             let boundingSize = CGSize(width: frame.size.width - textContainerInset.left - textContainerInset.right, height: .greatestFiniteMagnitude)
             let size = text.boundingRect(with: boundingSize, options: NSStringDrawingOptions.usesLineFragmentOrigin, attributes: attributes, context: nil)
             newHeight = ceil(size.height)


### PR DESCRIPTION
NSAttributedStringName renamed to NSAttributedStringKey